### PR TITLE
Fixes for Linux (Ubuntu) installation

### DIFF
--- a/PlaybackWindow.cpp
+++ b/PlaybackWindow.cpp
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <pcap.h>
 #include <pthread.h>
+#include <unistd.h>
 
 #include "PlaybackWindow.h"
 #include "InterfaceWindow.h"

--- a/README.txt
+++ b/README.txt
@@ -21,7 +21,7 @@ To install the 3rd party dependencies on an Ubuntu system, GCC must first be
 installed. If it has not already been installed, run:
   sudo apt-get install build-essential
 Then run the following:
-  sudo apt-get install libfox-dev libpcap-dev cmake
+  sudo apt-get install libfox-1.6-dev libpcap0.8-dev cmake
 
 To build the software, run the following commands from inside the source
 distribution:


### PR DESCRIPTION
Package names in readme were incorrect. 
Also, when running make, encountered this error: 
`~/repos/PlayCap/PlaybackWindow.cpp: In member function ‘void PlaybackWindow::playbackThread()’:
~/repos/PlayCap/PlaybackWindow.cpp:339:28: error: ‘usleep’ was not declared in this scope
    usleep(SLEEP_MILLIS*1000);`

Simply added `#include <unistd.h>` which is the header that defines `usleep()`